### PR TITLE
Add parameters

### DIFF
--- a/R/interpolate_pupil.R
+++ b/R/interpolate_pupil.R
@@ -9,7 +9,7 @@
 #' 
 #' @return data frame containing interpolated data 
 #' 
-interpolate_pupil<-function(datafile, extendblinks=FALSE, maxgap=Inf, type=NULL, hz=NA) {
+interpolate_pupil<-function(datafile, pupil, subject, trial, extendblinks=FALSE, maxgap=Inf, type=c("linear", "cubic"), hz=NA) {
 #supports linear and cublic-spline interpolation
   if (maxgap!=Inf){
     maxgap <- round(maxgap/(1000/hz))


### PR DESCRIPTION
Pupil, subject, and trial are now required from the user. 
Given the absence of default for `type = NULL`, list the possible types.